### PR TITLE
big.js types workaround

### DIFF
--- a/src/extensions/ribocode/utils/bigjs.d.ts
+++ b/src/extensions/ribocode/utils/bigjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'big.js';


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
Added a fallback `declare module 'big.js';` because the CI build does not recognize the built-in types from `big.js@7.x`, even though it works locally. This disables type checking for `big.js` as a temporary workaround until the CI environment can properly resolve the package's built-in types.

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`